### PR TITLE
refactor: comprehensive SIAC codebase revision

### DIFF
--- a/python/siac/__init__.py
+++ b/python/siac/__init__.py
@@ -13,6 +13,7 @@ Example usage:
     >>> result = siac.process("/path/to/S2_SAFE/")
 """
 
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
@@ -22,44 +23,24 @@ except PackageNotFoundError:
     __version__ = "2.0.0-dev"
 
 
-# Lazy imports for main API
+# Lazy imports for main API: maps name -> (module_path, attribute_name)
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "SIAC": ("siac.api", "SIAC"),
+    "SIACConfig": ("siac.config", "SIACConfig"),
+    "PreparedMonthlyCompositeBuildResult": ("siac.api", "PreparedMonthlyCompositeBuildResult"),
+    "process_sentinel2": ("siac.api", "process_sentinel2"),
+    "prepare_monthly_composites": ("siac.api", "prepare_monthly_composites"),
+    "process_landsat8": ("siac.api", "process_landsat8"),
+    "resolve_s2_input": ("siac.api", "resolve_s2_input"),
+    "siac_process_s2": ("siac.api", "siac_process_s2"),
+    "search_sentinel2": ("siac.api", "search_sentinel2"),
+}
+
+
 def __getattr__(name: str) -> Any:
-    if name == "SIAC":
-        from siac.api import SIAC
-
-        return SIAC
-    if name == "SIACConfig":
-        from siac.config import SIACConfig
-
-        return SIACConfig
-    if name == "PreparedMonthlyCompositeBuildResult":
-        from siac.api import PreparedMonthlyCompositeBuildResult
-
-        return PreparedMonthlyCompositeBuildResult
-    if name == "process_sentinel2":
-        from siac.api import process_sentinel2
-
-        return process_sentinel2
-    if name == "prepare_monthly_composites":
-        from siac.api import prepare_monthly_composites
-
-        return prepare_monthly_composites
-    if name == "process_landsat8":
-        from siac.api import process_landsat8
-
-        return process_landsat8
-    if name == "resolve_s2_input":
-        from siac.api import resolve_s2_input
-
-        return resolve_s2_input
-    if name == "siac_process_s2":
-        from siac.api import siac_process_s2
-
-        return siac_process_s2
-    if name == "search_sentinel2":
-        from siac.api import search_sentinel2
-
-        return search_sentinel2
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        return getattr(import_module(module_path), attr_name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 

--- a/python/siac/algorithms/correction/atmospheric.py
+++ b/python/siac/algorithms/correction/atmospheric.py
@@ -3,21 +3,22 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
-from scipy import ndimage
 
 from siac.domain.protocols import RTModelBackend
+from siac.geo.resample import (
+    resample_coefficients_to_template,
+    resample_mask_to_template,
+)
 from siac.runtime import (
     AtmosphericState,
     CorrectionDiagnostics,
     CorrectionResult,
     GeometryAngles,
-    RTCoefficients,
 )
-from siac.runtime.models import copy_spatial_metadata_like
 
 if TYPE_CHECKING:
     from siac.domain import SensorConfig
@@ -27,227 +28,8 @@ logger = logging.getLogger(__name__)
 _TOA_BAND_LOADER_ATTR = "_siac_toa_band_loader"
 
 
-def _shares_template_grid(field: xr.DataArray, template: xr.DataArray) -> bool:
-    if tuple(field.shape) != tuple(template.shape):
-        return False
-    if tuple(field.dims) != tuple(template.dims):
-        return False
-    for dim in template.dims:
-        if dim not in field.coords or dim not in template.coords:
-            return False
-        if not np.array_equal(np.asarray(field.coords[dim].values), np.asarray(template.coords[dim].values), equal_nan=True):
-            return False
-    return True
-
-
-def _axis_resolution(values: np.ndarray) -> float | None:
-    if values.size <= 1:
-        return None
-    diffs = np.abs(np.diff(np.asarray(values, dtype=np.float64)))
-    finite = diffs[np.isfinite(diffs) & (diffs > 0.0)]
-    if finite.size == 0:
-        return None
-    return float(np.median(finite))
-
-
-def _resample_mask_to_template(mask: xr.DataArray, template: xr.DataArray) -> xr.DataArray:
-    if _shares_template_grid(mask, template):
-        return copy_spatial_metadata_like(mask.astype(bool), template)
-
-    if (
-        len(mask.dims) == 2
-        and mask.dims == template.dims
-        and all(dim in mask.coords for dim in mask.dims)
-        and all(dim in template.coords for dim in template.dims)
-    ):
-        source = np.asarray(mask.values, dtype=np.float32)
-        factor_y = 1
-        factor_x = 1
-        src_y_res = _axis_resolution(np.asarray(mask.coords[mask.dims[0]].values))
-        src_x_res = _axis_resolution(np.asarray(mask.coords[mask.dims[1]].values))
-        dst_y_res = _axis_resolution(np.asarray(template.coords[template.dims[0]].values))
-        dst_x_res = _axis_resolution(np.asarray(template.coords[template.dims[1]].values))
-        if src_y_res is not None and dst_y_res is not None and dst_y_res > src_y_res:
-            factor_y = max(1, int(np.ceil(dst_y_res / src_y_res)))
-        if src_x_res is not None and dst_x_res is not None and dst_x_res > src_x_res:
-            factor_x = max(1, int(np.ceil(dst_x_res / src_x_res)))
-        if factor_y > 1 or factor_x > 1:
-            source = ndimage.maximum_filter(source, size=(factor_y, factor_x), mode="nearest")
-
-        remapped = xr.DataArray(
-            source,
-            dims=mask.dims,
-            coords={dim: mask.coords[dim] for dim in mask.dims},
-            attrs=mask.attrs,
-        )
-        try:
-            interpolated = remapped.interp(
-                coords={dim: template.coords[dim] for dim in template.dims},
-                method="nearest",
-            )
-            values = np.asarray(interpolated.values, dtype=np.float32)
-            values = np.where(np.isfinite(values), values, 1.0)
-            return copy_spatial_metadata_like(
-                xr.DataArray(
-                    values > 0.5,
-                    dims=template.dims,
-                    coords={dim: template.coords[dim] for dim in template.dims if dim in template.coords},
-                    attrs=mask.attrs,
-                ),
-                template,
-            )
-        except Exception as exc:
-            logger.warning(
-                "Mask coordinate-based resampling failed (%s); falling back to zoom resampling",
-                exc,
-            )
-
-    src = np.asarray(mask.values, dtype=np.float32)
-    h_out = int(template.sizes[template.dims[0]])
-    w_out = int(template.sizes[template.dims[1]])
-    factor_y = max(1, src.shape[0] // h_out) if src.ndim == 2 and h_out > 0 else 1
-    factor_x = max(1, src.shape[1] // w_out) if src.ndim == 2 and w_out > 0 else 1
-    if src.ndim != 2:
-        out = np.ones((h_out, w_out), dtype=np.float32)
-    else:
-        dilated = ndimage.maximum_filter(src, size=(factor_y, factor_x), mode="nearest")
-        out = ndimage.zoom(dilated, (h_out / dilated.shape[0], w_out / dilated.shape[1]), order=0)
-        out = out[:h_out, :w_out]
-        if out.shape != (h_out, w_out):
-            padded: np.ndarray[Any, Any] = np.ones((h_out, w_out), dtype=np.float32)
-            padded[: out.shape[0], : out.shape[1]] = out
-            out = padded
-    return copy_spatial_metadata_like(
-        xr.DataArray(
-            out > 0.5,
-            dims=template.dims,
-            coords={dim: template.coords[dim] for dim in template.dims if dim in template.coords},
-            attrs=mask.attrs,
-        ),
-        template,
-    )
-
-
-def _resample_field_to_template(field: xr.DataArray, template: xr.DataArray) -> xr.DataArray:
-    if _shares_template_grid(field, template):
-        return copy_spatial_metadata_like(field, template)
-
-    resampled: xr.DataArray | None = None
-    if (
-        len(field.dims) == 2
-        and field.dims == template.dims
-        and all(dim in field.coords for dim in field.dims)
-        and all(dim in template.coords for dim in template.dims)
-    ):
-        try:
-            interpolated = field.interp(
-                coords={dim: template.coords[dim] for dim in template.dims},
-                method="linear",
-            )
-            resampled = copy_spatial_metadata_like(interpolated, template)
-        except Exception as exc:
-            logger.warning(
-                "Linear interpolation failed for field %s (%s); falling back to zoom resampling",
-                getattr(field, "name", "?"),
-                exc,
-            )
-
-    if resampled is None:
-        src = np.asarray(field.values, dtype=np.float32)
-        if src.ndim != 2 or len(template.dims) != 2:
-            return field
-
-        h_out = int(template.sizes[template.dims[0]])
-        w_out = int(template.sizes[template.dims[1]])
-        if src.shape[0] == 0 or src.shape[1] == 0:
-            out: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
-        else:
-            out = ndimage.zoom(src, (h_out / src.shape[0], w_out / src.shape[1]), order=1)
-            out = out[:h_out, :w_out]
-            if out.shape != (h_out, w_out):
-                padded: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
-                padded[: out.shape[0], : out.shape[1]] = out
-                out = padded
-
-        resampled = xr.DataArray(
-            out.astype(np.float32),
-            dims=template.dims,
-            coords={dim: template.coords[dim] for dim in template.dims if dim in template.coords},
-            attrs=field.attrs,
-        )
-        resampled = copy_spatial_metadata_like(resampled, template)
-
-    values = np.asarray(resampled.values, dtype=np.float32)
-    if np.all(np.isfinite(values)):
-        return resampled
-
-    filled = values.copy()
-    if (
-        len(field.dims) == 2
-        and field.dims == template.dims
-        and all(dim in field.coords for dim in field.dims)
-        and all(dim in template.coords for dim in template.dims)
-    ):
-        try:
-            nearest = field.interp(
-                coords={dim: template.coords[dim] for dim in template.dims},
-                method="nearest",
-            )
-            filled = np.where(np.isfinite(filled), filled, np.asarray(nearest.values, dtype=np.float32))
-        except Exception as exc:
-            logger.warning(
-                "Nearest-neighbour gap-fill failed for field %s (%s); "
-                "remaining NaN values will be filled with source mean",
-                getattr(field, "name", "?"),
-                exc,
-            )
-
-    if not np.all(np.isfinite(filled)):
-        source_values = np.asarray(field.values, dtype=np.float32)
-        finite_source = source_values[np.isfinite(source_values)]
-        fill_value = float(finite_source.mean()) if finite_source.size else 0.0
-        n_nan = int(np.sum(~np.isfinite(filled)))
-        logger.warning(
-            "Filling %d remaining NaN pixels in field %s with source mean %.4g",
-            n_nan,
-            getattr(field, "name", "?"),
-            fill_value,
-        )
-        filled = np.where(np.isfinite(filled), filled, np.float32(fill_value))
-
-    return resampled.copy(data=filled)
-
-
-def _resample_coefficients_to_template(
-    coeffs: RTCoefficients,
-    template: xr.DataArray,
-) -> RTCoefficients:
-    def _resample_optional(field: xr.DataArray | None) -> xr.DataArray | None:
-        if field is None:
-            return None
-        if len(field.dims) == 2:
-            return _resample_field_to_template(field, template)
-        if len(field.dims) == 3 and "param" in field.dims:
-            param_values = field.coords["param"].values if "param" in field.coords else np.arange(field.sizes["param"])
-            stacked = xr.concat(
-                [_resample_field_to_template(field.sel(param=param, drop=True), template) for param in param_values],
-                dim="param",
-            )
-            return stacked.assign_coords(param=param_values).transpose("param", *template.dims)
-        return field
-
-    return RTCoefficients(
-        xap=_resample_field_to_template(coeffs.xap, template),
-        xbp=_resample_field_to_template(coeffs.xbp, template),
-        xcp=_resample_field_to_template(coeffs.xcp, template),
-        d_xap=_resample_optional(coeffs.d_xap),
-        d_xbp=_resample_optional(coeffs.d_xbp),
-        d_xcp=_resample_optional(coeffs.d_xcp),
-    )
-
-
 class AtmosphericCorrector:
-    def __init__(self, rt_model: Any, sensor_config: SensorConfig):
+    def __init__(self, rt_model: RTModelBackend, sensor_config: SensorConfig):
         if not isinstance(rt_model, RTModelBackend):
             raise TypeError(
                 f"rt_model must implement RTModelBackend protocol, "
@@ -276,7 +58,7 @@ class AtmosphericCorrector:
             if band_data is None:
                 continue
             coeffs = self.rt_model.compute_coefficients(geometry, atmo_state, band_spec, False)
-            coeffs = _resample_coefficients_to_template(coeffs, band_data)
+            coeffs = resample_coefficients_to_template(coeffs, band_data)
             boa = coeffs.apply_correction(band_data)
             band_valid = np.isfinite(boa) & (boa > -0.05) & (boa < 1.5)
             boa_vars[band_name] = boa.where(band_valid)
@@ -301,7 +83,7 @@ class AtmosphericCorrector:
 
         # cloud_mask contract: True = cloudy/invalid, preserved from M1
         if cloud_mask is not None:
-            final_cloud_mask = _resample_mask_to_template(cloud_mask, invalid_boa_mask) | invalid_boa_mask.astype(bool)
+            final_cloud_mask = resample_mask_to_template(cloud_mask, invalid_boa_mask) | invalid_boa_mask.astype(bool)
         else:
             final_cloud_mask = invalid_boa_mask.astype(bool)
         elapsed = time.monotonic() - t0

--- a/python/siac/algorithms/solver/cost.py
+++ b/python/siac/algorithms/solver/cost.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import xarray as xr
@@ -50,8 +50,8 @@ class CostFunctionConfig:
     tcwv_min: float = 0.0
     tcwv_max: float = 8.0
 
-    # Band weighting power (alpha = -2 weights shorter wavelengths more)
-    band_weight_power: float = -2.0
+    # Band weighting power (negative values weight shorter wavelengths more for AOT)
+    band_weight_power: float = -1.6
 
     # Minimum uncertainty floor
     min_boa_unc: float = 0.001
@@ -73,7 +73,7 @@ class CostFunction:
         surface_prior: SurfacePrior,
         geometry: GeometryAngles,
         atmo_prior: AtmosphericState,
-        rt_model: Any,  # RTModelBackend protocol
+        rt_model: RTModelBackend,
         bands: list[SensorBand],
         mask: xr.DataArray,
         config: CostFunctionConfig | None = None,
@@ -112,6 +112,19 @@ class CostFunction:
 
         # Setup prior arrays
         self._setup_priors()
+
+        # Pre-allocate mutable DataArrays for the optimizer inner loop to
+        # avoid reconstructing xarray objects on every L-BFGS-B iteration.
+        self._aot_da = xr.DataArray(
+            self.atmo_prior.aot.values.copy(),
+            dims=self.atmo_prior.aot.dims,
+            coords=self.atmo_prior.aot.coords,
+        )
+        self._tcwv_da = xr.DataArray(
+            self.atmo_prior.tcwv.values.copy(),
+            dims=self.atmo_prior.tcwv.dims,
+            coords=self.atmo_prior.tcwv.coords,
+        )
 
         # Setup band weights
         self._setup_band_weights()
@@ -261,10 +274,12 @@ class CostFunction:
         dj_aot = np.zeros(self.shape)
         dj_tcwv = np.zeros(self.shape)
 
-        # Create temporary atmospheric state with current parameters
+        # Update pre-allocated DataArrays in-place to avoid xarray overhead
+        self._aot_da.values[:] = aot
+        self._tcwv_da.values[:] = tcwv
         atmo_state = self.atmo_prior.with_updated_aot_tcwv(
-            aot=xr.DataArray(aot, dims=self.atmo_prior.aot.dims),
-            tcwv=xr.DataArray(tcwv, dims=self.atmo_prior.tcwv.dims),
+            aot=self._aot_da,
+            tcwv=self._tcwv_da,
         )
 
         # Compute RT coefficients for all bands (batch if supported)
@@ -486,18 +501,13 @@ def create_sparse_laplacian(nx: int, ny: int) -> sparse.csc_matrix:
     off_diag_ny = -1 * np.ones(n)
 
     # Boundary adjustments (Neumann: reduce diagonal at edges)
-    for i in range(n):
-        row = i // ny
-        col = i % ny
-
-        if row == 0:
-            main_diag[i] -= 1
-        if row == nx - 1:
-            main_diag[i] -= 1
-        if col == 0:
-            main_diag[i] -= 1
-        if col == ny - 1:
-            main_diag[i] -= 1
+    indices = np.arange(n)
+    rows = indices // ny
+    cols = indices % ny
+    main_diag[rows == 0] -= 1.0
+    main_diag[rows == nx - 1] -= 1.0
+    main_diag[cols == 0] -= 1.0
+    main_diag[cols == ny - 1] -= 1.0
 
     # Build sparse matrix
     laplacian = sparse.diags(

--- a/python/siac/algorithms/solver/multigrid.py
+++ b/python/siac/algorithms/solver/multigrid.py
@@ -100,6 +100,9 @@ class MultiGridConfig:
     aot_gamma: float = 10.0
     tcwv_gamma: float = 5.0
 
+    # Band weighting power (negative values weight shorter wavelengths more)
+    band_weight_power: float = -1.6
+
     # Convergence threshold for early stopping
     rel_tol: float = 1e-4
 
@@ -152,7 +155,7 @@ class MultiGridSolver:
         surface_prior: SurfacePrior,
         geometry: GeometryAngles,
         atmo_prior: AtmosphericState,
-        rt_model: Any,  # RTModelBackend protocol
+        rt_model: RTModelBackend,
         cloud_mask: xr.DataArray,
         bands: list[SensorBand],
         sharp_transition_mask: xr.DataArray | None = None,
@@ -253,6 +256,7 @@ class MultiGridSolver:
                 aot_max=self.config.aot_bounds[1],
                 tcwv_min=self.config.tcwv_bounds[0],
                 tcwv_max=self.config.tcwv_bounds[1],
+                band_weight_power=self.config.band_weight_power,
             )
 
             # Resample data to current grid
@@ -405,7 +409,7 @@ class MultiGridSolver:
         return result
 
     @staticmethod
-    def _rt_model_supports_jacobian(rt_model: Any) -> bool:
+    def _rt_model_supports_jacobian(rt_model: RTModelBackend) -> bool:
         """Return whether backend can provide per-pixel RT Jacobians."""
         fn = getattr(rt_model, "supports_jacobian", None)
         if callable(fn):
@@ -539,7 +543,7 @@ class MultiGridSolver:
         surface_prior: SurfacePrior,
         geometry: GeometryAngles,
         atmo_prior: AtmosphericState,
-        rt_model: Any,
+        rt_model: RTModelBackend,
         mask: xr.DataArray,
         bands: list[SensorBand],
         cost_config: CostFunctionConfig,
@@ -980,7 +984,7 @@ def solve_atmospheric_parameters(
     surface_prior: SurfacePrior,
     geometry: GeometryAngles,
     atmo_prior: AtmosphericState,
-    rt_model: Any,
+    rt_model: RTModelBackend,
     cloud_mask: xr.DataArray,
     bands: list[SensorBand],
     config: MultiGridConfig | None = None,

--- a/python/siac/app/_assembly_runtime.py
+++ b/python/siac/app/_assembly_runtime.py
@@ -337,7 +337,7 @@ def resolve_rt_model_for_pipeline(
     *,
     sensor_config: SensorConfig | None = None,
 ) -> RTModelBackend:
-    return build_rt_model(config, auth=auth, sensor_config=sensor_config)
+    return build_rt_model(config, auth=auth, sensor_config=sensor_config)  # type: ignore[no-any-return]
 
 
 __all__ = [

--- a/python/siac/app/_assembly_runtime.py
+++ b/python/siac/app/_assembly_runtime.py
@@ -8,14 +8,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-import numpy as np
-
 from siac.adapters.output import ConfiguredOutputWriter
 from siac.adapters.rt import build_rt_model
 from siac.adapters.satellite import detect_sensor, get_preprocessor
 from siac.algorithms.correction import AtmosphericCorrector, CorrectionResult
 from siac.algorithms.solver import MultiGridConfig, MultiGridSolver
 from siac.domain.aoi import AOI
+from siac.geo.resample import (
+    resample_field_for_correction as _resample_field_for_correction,
+)
+from siac.geo.resample import (
+    resample_field_to_template as _resample_field_to_template,  # noqa: F401
+)
+from siac.geo.resample import (
+    shares_template_grid as _shares_template_grid,  # noqa: F401
+)
 from siac.runtime import (
     AtmosphericState,
     GeometryAngles,
@@ -27,6 +34,7 @@ from siac.runtime import (
 if TYPE_CHECKING:
     import xarray as xr
 
+    from siac.domain.protocols import RTModelBackend
     from siac.domain.sensors import SensorConfig
     from siac.workflows.pipeline import CorrectorFn, GridAssemblerFn, PreprocessorFn, SolverFn
 
@@ -240,6 +248,7 @@ def resolve_solver(config: Any) -> SolverFn:
             tcwv_gamma=config.solver.tcwv_gamma,
             aot_bounds=tuple(config.solver.aot_bounds),
             tcwv_bounds=tuple(config.solver.tcwv_bounds),
+            band_weight_power=getattr(config.solver, "alpha", -1.6),
         )
         mg_solver = MultiGridSolver(solver_config)
         solve_kwargs: dict[str, Any] = {}
@@ -279,126 +288,6 @@ def resolve_solver(config: Any) -> SolverFn:
     return _default_solver
 
 
-def _shares_template_grid(field: Any, template: Any) -> bool:
-    """Return True when a field already matches the template's spatial grid."""
-    if tuple(getattr(field, "shape", ())) != tuple(getattr(template, "shape", ())):
-        return False
-
-    field_dims = tuple(getattr(field, "dims", ()))
-    template_dims = tuple(getattr(template, "dims", ()))
-    if field_dims != template_dims:
-        return False
-
-    field_coords = getattr(field, "coords", {})
-    template_coords = getattr(template, "coords", {})
-    for axis in template_dims:
-        field_has_coord = axis in field_coords
-        template_has_coord = axis in template_coords
-        if field_has_coord != template_has_coord:
-            return False
-        if not field_has_coord:
-            continue
-        field_values = np.asarray(field.coords[axis].values)
-        template_values = np.asarray(template.coords[axis].values)
-        if not np.array_equal(field_values, template_values, equal_nan=True):
-            return False
-    return True
-
-
-def _resample_field_to_template(field: Any, template: Any) -> Any:
-    if _shares_template_grid(field, template):
-        return field
-    if (
-        len(field.dims) == 2
-        and field.dims == template.dims
-        and all(dim in field.coords for dim in field.dims)
-        and all(dim in template.coords for dim in template.dims)
-    ):
-        try:
-            return field.interp(
-                coords={dim: template.coords[dim] for dim in template.dims},
-                method="linear",
-            )
-        except Exception:
-            pass
-
-    src = np.asarray(field.values, dtype=np.float32)
-    if src.ndim != 2 or len(template.dims) != 2:
-        return field
-
-    from scipy import ndimage
-
-    h_out = int(template.sizes[template.dims[0]])
-    w_out = int(template.sizes[template.dims[1]])
-    if src.shape[0] == 0 or src.shape[1] == 0:
-        out: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
-    else:
-        out = ndimage.zoom(src, (h_out / src.shape[0], w_out / src.shape[1]), order=1)
-        out = out[:h_out, :w_out]
-        if out.shape != (h_out, w_out):
-            padded: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
-            padded[: out.shape[0], : out.shape[1]] = out
-            out = padded
-
-    return field.__class__(
-        out,
-        dims=template.dims,
-        coords={d: template.coords[d] for d in template.dims if d in template.coords},
-    )
-
-
-def _fill_nonfinite_like_template(
-    field: Any,
-    source: Any,
-    template: Any,
-    *,
-    fallback_value: float = 0.0,
-) -> Any:
-    values = np.asarray(field.values, dtype=np.float32)
-    if np.all(np.isfinite(values)):
-        return field
-
-    filled = values.copy()
-    if (
-        len(source.dims) == 2
-        and source.dims == template.dims
-        and all(dim in source.coords for dim in source.dims)
-        and all(dim in template.coords for dim in template.dims)
-    ):
-        try:
-            nearest = source.interp(
-                coords={dim: template.coords[dim] for dim in template.dims},
-                method="nearest",
-            )
-            nearest_values = np.asarray(nearest.values, dtype=np.float32)
-            filled = np.where(np.isfinite(filled), filled, nearest_values)
-        except Exception:
-            pass
-
-    if not np.all(np.isfinite(filled)):
-        source_values = np.asarray(source.values, dtype=np.float32)
-        finite_source = source_values[np.isfinite(source_values)]
-        fill_value = float(finite_source.mean()) if finite_source.size else float(fallback_value)
-        filled = np.where(np.isfinite(filled), filled, np.float32(fill_value))
-
-    return field.copy(data=filled)
-
-
-def _resample_field_to_template_for_correction(
-    field: Any,
-    template: Any,
-    *,
-    fallback_value: float = 0.0,
-) -> Any:
-    """Resample atmosphere fields to the correction grid and guarantee finiteness."""
-    return _fill_nonfinite_like_template(
-        _resample_field_to_template(field, template),
-        field,
-        template,
-        fallback_value=fallback_value,
-    )
-
-
 def resolve_corrector(_config: Any) -> CorrectorFn:
     def _default_corrector(
         obs: ObservationBundle,
@@ -408,19 +297,19 @@ def resolve_corrector(_config: Any) -> CorrectorFn:
         corrector_obj = AtmosphericCorrector(rt_model, obs.sensor_config)
         atmo = solved.atmo_state
         matched_atmo = AtmosphericState(
-            aot=_resample_field_to_template_for_correction(atmo.aot, atmo.aot),
-            tcwv=_resample_field_to_template_for_correction(atmo.tcwv, atmo.aot),
-            tco3=_resample_field_to_template_for_correction(atmo.tco3, atmo.aot),
-            aot_unc=_resample_field_to_template_for_correction(atmo.aot_unc, atmo.aot),
-            tcwv_unc=_resample_field_to_template_for_correction(atmo.tcwv_unc, atmo.aot),
-            tco3_unc=_resample_field_to_template_for_correction(atmo.tco3_unc, atmo.aot),
-            elevation=_resample_field_to_template_for_correction(atmo.elevation, atmo.aot),
+            aot=_resample_field_for_correction(atmo.aot, atmo.aot),
+            tcwv=_resample_field_for_correction(atmo.tcwv, atmo.aot),
+            tco3=_resample_field_for_correction(atmo.tco3, atmo.aot),
+            aot_unc=_resample_field_for_correction(atmo.aot_unc, atmo.aot),
+            tcwv_unc=_resample_field_for_correction(atmo.tcwv_unc, atmo.aot),
+            tco3_unc=_resample_field_for_correction(atmo.tco3_unc, atmo.aot),
+            elevation=_resample_field_for_correction(atmo.elevation, atmo.aot),
         )
         coeff_geometry = GeometryAngles(
-            sza=_resample_field_to_template_for_correction(obs.geometry.sza, atmo.aot),
-            saa=_resample_field_to_template_for_correction(obs.geometry.saa, atmo.aot),
-            vza=_resample_field_to_template_for_correction(obs.geometry.vza, atmo.aot),
-            vaa=_resample_field_to_template_for_correction(obs.geometry.vaa, atmo.aot),
+            sza=_resample_field_for_correction(obs.geometry.sza, atmo.aot),
+            saa=_resample_field_for_correction(obs.geometry.saa, atmo.aot),
+            vza=_resample_field_for_correction(obs.geometry.vza, atmo.aot),
+            vaa=_resample_field_for_correction(obs.geometry.vaa, atmo.aot),
         )
         corrected = corrector_obj.correct(obs.toa, coeff_geometry, matched_atmo, obs.cloud_mask)
         if not isinstance(corrected, CorrectionResult):
@@ -447,14 +336,12 @@ def resolve_rt_model_for_pipeline(
     auth: Any = None,
     *,
     sensor_config: SensorConfig | None = None,
-) -> Any:
+) -> RTModelBackend:
     return build_rt_model(config, auth=auth, sensor_config=sensor_config)
 
 
 __all__ = [
     "PreprocessorRuntime",
-    "_resample_field_to_template",
-    "_shares_template_grid",
     "build_preprocessor_runtime",
     "resolve_corrector",
     "resolve_grid_assembler",

--- a/python/siac/app/assembly.py
+++ b/python/siac/app/assembly.py
@@ -27,7 +27,6 @@ from siac.app._assembly_providers import (
 )
 from siac.app._assembly_runtime import (
     PreprocessorRuntime,
-    _resample_field_to_template,
     build_preprocessor_runtime,
     resolve_corrector,
     resolve_grid_assembler,
@@ -323,12 +322,6 @@ def resolve_s2_backend(config: Any, *, auth: CredentialManager | None = None) ->
 
 __all__ = [
     "PreprocessorRuntime",
-    "_build_kernel_surface_prior",
-    "_build_monthly_surface_prior",
-    "_build_whittaker_surface_prior",
-    "_query_monthly_surface_prior",
-    "_prepare_monthly_surface_prior_runtime",
-    "_resample_field_to_template",
     "build_preprocessor_runtime",
     "resolve_atmo_provider",
     "resolve_brdf_provider",

--- a/python/siac/config/schema.py
+++ b/python/siac/config/schema.py
@@ -643,7 +643,7 @@ class ResolvedConfig(_ConfigShortcutsMixin, SIACBaseModel):
     paths: ResolvedPathsConfig
     auth: ResolvedAuthConfig
     providers: ResolvedProvidersConfig
-    algorithms: ResolvedAlgorithmsConfig
+    algorithms: ResolvedAlgorithmsConfig  # type: ignore[assignment]
     runtime: RuntimeConfig
     output: OutputConfig
 

--- a/python/siac/config/schema.py
+++ b/python/siac/config/schema.py
@@ -8,7 +8,7 @@ resolution, and snapshotting live in sibling modules.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
@@ -168,13 +168,6 @@ class AtmoProviderConfig(SIACBaseModel):
     def provider(self) -> AtmoProviderKind:
         return self.kind
 
-    @provider.setter
-    def provider(self, value: str) -> None:
-        allowed = {"cams", "merra2", "mcd19", "vnp19", "era5", "user"}
-        if value not in allowed:
-            raise ValueError(f"Invalid atmo provider {value!r}; expected one of {sorted(allowed)!r}.")
-        self.kind = cast("AtmoProviderKind", value)
-
 
 class BRDFProviderConfig(SIACBaseModel):
     kind: BRDFProviderKind = Field(
@@ -202,13 +195,6 @@ class BRDFProviderConfig(SIACBaseModel):
     @property
     def provider(self) -> BRDFProviderKind:
         return self.kind
-
-    @provider.setter
-    def provider(self, value: str) -> None:
-        allowed = {"mcd43", "vnp43", "mcd19", "gee", "zarr", "user"}
-        if value not in allowed:
-            raise ValueError(f"Invalid brdf provider {value!r}; expected one of {sorted(allowed)!r}.")
-        self.kind = cast("BRDFProviderKind", value)
 
 
 class S2ProviderConfig(SIACBaseModel):
@@ -242,15 +228,6 @@ class MonthlyCompositeProviderConfig(SIACBaseModel):
     @property
     def provider(self) -> MonthlyCompositeProviderKind:
         return self.kind
-
-    @provider.setter
-    def provider(self, value: str) -> None:
-        allowed = {"generated_brdf", "user_callable", "prepared_store"}
-        if value not in allowed:
-            raise ValueError(
-                f"Invalid monthly composite provider {value!r}; expected one of {sorted(allowed)!r}."
-            )
-        self.kind = cast("MonthlyCompositeProviderKind", value)
 
 
 class ProvidersConfig(SIACBaseModel):
@@ -467,29 +444,18 @@ class OutputConfig(SIACBaseModel):
     defaults: OutputDefaultsConfig = Field(default_factory=OutputDefaultsConfig)
 
 
-class SystemConfig(SIACBaseModel):
-    paths: PathsConfig = Field(default_factory=PathsConfig)
-    auth: AuthConfig = Field(default_factory=AuthConfig)
-    providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
-    algorithms: AlgorithmsConfig = Field(default_factory=AlgorithmsConfig)
-    runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
-    output: OutputConfig = Field(default_factory=OutputConfig)
+class _ConfigShortcutsMixin:
+    """Shared shortcut properties for both SystemConfig and ResolvedConfig.
 
-    @property
-    def atmo_prior(self) -> AtmoProviderConfig:
-        return self.providers.atmo
+    Both config classes have identical ``algorithms``, ``runtime``, ``output``,
+    and ``paths`` sub-structures. This mixin deduplicates the accessor
+    properties that navigate into those sub-structures.
+    """
 
-    @property
-    def brdf(self) -> BRDFProviderConfig:
-        return self.providers.brdf
-
-    @property
-    def surface_prior(self) -> SurfacePriorAlgorithmConfig:
-        return self.algorithms.surface_prior
-
-    @property
-    def rt_model(self) -> RTAlgorithmConfig:
-        return self.algorithms.rt
+    algorithms: AlgorithmsConfig  # type: ignore[assignment]
+    runtime: RuntimeConfig
+    output: OutputConfig
+    paths: PathsConfig | ResolvedPathsConfig
 
     @property
     def solver(self) -> SolverAlgorithmConfig:
@@ -498,14 +464,6 @@ class SystemConfig(SIACBaseModel):
     @property
     def cloud_mask(self) -> CloudMaskAlgorithmConfig:
         return self.algorithms.cloud_mask
-
-    @property
-    def s2_data(self) -> S2ProviderConfig:
-        return self.providers.s2
-
-    @property
-    def monthly_composites(self) -> MonthlyCompositeProviderConfig:
-        return self.providers.monthly_composites
 
     @property
     def execution(self) -> ExecutionRuntimeConfig:
@@ -532,6 +490,39 @@ class SystemConfig(SIACBaseModel):
         return self.runtime.chunk_size
 
 
+class SystemConfig(_ConfigShortcutsMixin, SIACBaseModel):
+    paths: PathsConfig = Field(default_factory=PathsConfig)
+    auth: AuthConfig = Field(default_factory=AuthConfig)
+    providers: ProvidersConfig = Field(default_factory=ProvidersConfig)
+    algorithms: AlgorithmsConfig = Field(default_factory=AlgorithmsConfig)
+    runtime: RuntimeConfig = Field(default_factory=RuntimeConfig)
+    output: OutputConfig = Field(default_factory=OutputConfig)
+
+    @property
+    def atmo_prior(self) -> AtmoProviderConfig:
+        return self.providers.atmo
+
+    @property
+    def brdf(self) -> BRDFProviderConfig:
+        return self.providers.brdf
+
+    @property
+    def surface_prior(self) -> SurfacePriorAlgorithmConfig:
+        return self.algorithms.surface_prior
+
+    @property
+    def rt_model(self) -> RTAlgorithmConfig:
+        return self.algorithms.rt
+
+    @property
+    def s2_data(self) -> S2ProviderConfig:
+        return self.providers.s2
+
+    @property
+    def monthly_composites(self) -> MonthlyCompositeProviderConfig:
+        return self.providers.monthly_composites
+
+
 class RunRequest(SIACBaseModel):
     input_path: Path | None = None
     output_path: Path | None = None
@@ -550,8 +541,7 @@ class RunRequest(SIACBaseModel):
         return _coerce_path_or_url(value)
 
 
-class ResolvedCachePathsConfig(CachePathsConfig):
-    pass
+ResolvedCachePathsConfig = CachePathsConfig
 
 
 class ResolvedPathsConfig(SIACBaseModel):
@@ -608,8 +598,7 @@ class ResolvedS2ProviderConfig(S2ProviderConfig):
     cache_dir: Path | None = None
 
 
-class ResolvedMonthlyCompositeProviderConfig(MonthlyCompositeProviderConfig):
-    pass
+ResolvedMonthlyCompositeProviderConfig = MonthlyCompositeProviderConfig
 
 
 class ResolvedProvidersConfig(SIACBaseModel):
@@ -649,7 +638,7 @@ class ResolvedRunConfig(SIACBaseModel):
     s2_query: str | Path | None = None
 
 
-class ResolvedConfig(SIACBaseModel):
+class ResolvedConfig(_ConfigShortcutsMixin, SIACBaseModel):
     run: ResolvedRunConfig
     paths: ResolvedPathsConfig
     auth: ResolvedAuthConfig
@@ -689,35 +678,3 @@ class ResolvedConfig(SIACBaseModel):
     @property
     def rt_model(self) -> ResolvedRTAlgorithmConfig:
         return self.algorithms.rt
-
-    @property
-    def solver(self) -> SolverAlgorithmConfig:
-        return self.algorithms.solver
-
-    @property
-    def cloud_mask(self) -> CloudMaskAlgorithmConfig:
-        return self.algorithms.cloud_mask
-
-    @property
-    def execution(self) -> ExecutionRuntimeConfig:
-        return self.runtime.execution
-
-    @property
-    def global_dem(self) -> str | Path | None:
-        return self.paths.dem
-
-    @property
-    def global_water(self) -> str | Path | None:
-        return self.paths.water_mask
-
-    @property
-    def log_level(self) -> LogLevel:
-        return self.runtime.log_level
-
-    @property
-    def n_jobs(self) -> int:
-        return self.runtime.n_jobs
-
-    @property
-    def chunk_size(self) -> int:
-        return self.runtime.chunk_size

--- a/python/siac/config/schema.py
+++ b/python/siac/config/schema.py
@@ -452,7 +452,7 @@ class _ConfigShortcutsMixin:
     properties that navigate into those sub-structures.
     """
 
-    algorithms: AlgorithmsConfig  # type: ignore[assignment]
+    algorithms: AlgorithmsConfig
     runtime: RuntimeConfig
     output: OutputConfig
     paths: PathsConfig | ResolvedPathsConfig
@@ -643,7 +643,7 @@ class ResolvedConfig(_ConfigShortcutsMixin, SIACBaseModel):
     paths: ResolvedPathsConfig
     auth: ResolvedAuthConfig
     providers: ResolvedProvidersConfig
-    algorithms: ResolvedAlgorithmsConfig  # type: ignore[assignment]
+    algorithms: ResolvedAlgorithmsConfig
     runtime: RuntimeConfig
     output: OutputConfig
 

--- a/python/siac/geo/__init__.py
+++ b/python/siac/geo/__init__.py
@@ -34,8 +34,24 @@ from siac.geo.reprojection import (
     transform_bounds,
     transform_points,
 )
+from siac.geo.resample import (
+    axis_resolution,
+    fill_nonfinite_like_template,
+    resample_coefficients_to_template,
+    resample_field_for_correction,
+    resample_field_to_template,
+    resample_mask_to_template,
+    shares_template_grid,
+)
 
 __all__ = [
+    "axis_resolution",
+    "fill_nonfinite_like_template",
+    "resample_coefficients_to_template",
+    "resample_field_for_correction",
+    "resample_field_to_template",
+    "resample_mask_to_template",
+    "shares_template_grid",
     "align_grids",
     "bounds_area",
     "bounds_contains",

--- a/python/siac/geo/resample.py
+++ b/python/siac/geo/resample.py
@@ -253,7 +253,8 @@ def resample_coefficients_to_template(
                 [resample_field_to_template(field.sel(param=param, drop=True), template) for param in param_values],
                 dim="param",
             )
-            return stacked.assign_coords(param=param_values).transpose("param", *template.dims)
+            result: xr.DataArray = stacked.assign_coords(param=param_values).transpose("param", *template.dims)
+            return result
         return field
 
     return RTCoefficientsClass(
@@ -307,7 +308,8 @@ def fill_nonfinite_like_template(
         )
         filled = np.where(np.isfinite(filled), filled, np.float32(fill_value))
 
-    return field.copy(data=filled)
+    result: xr.DataArray = field.copy(data=filled)
+    return result
 
 
 def resample_field_for_correction(

--- a/python/siac/geo/resample.py
+++ b/python/siac/geo/resample.py
@@ -1,0 +1,336 @@
+"""Shared resampling utilities for aligning xarray fields to a common grid.
+
+These functions are used across the pipeline orchestrator, the atmospheric
+corrector, and the assembly layer to resample 2-D xarray DataArrays between
+different spatial grids (e.g. atmospheric prior grid -> solver grid ->
+native pixel grid).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import xarray as xr
+from scipy import ndimage
+
+from siac.runtime.models import copy_spatial_metadata_like
+
+if TYPE_CHECKING:
+    from siac.runtime import RTCoefficients
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Grid comparison
+# ---------------------------------------------------------------------------
+
+def shares_template_grid(field: xr.DataArray, template: xr.DataArray) -> bool:
+    """Return True when *field* already sits on the same spatial grid as *template*.
+
+    Checks shape, dims, and coordinate arrays for equality.
+    """
+    if tuple(field.shape) != tuple(template.shape):
+        return False
+    if tuple(field.dims) != tuple(template.dims):
+        return False
+    for dim in template.dims:
+        template_has_coord = dim in template.coords
+        field_has_coord = dim in field.coords
+        if template_has_coord != field_has_coord:
+            return False
+        if not template_has_coord:
+            continue
+        if not np.array_equal(
+            np.asarray(template.coords[dim].values),
+            np.asarray(field.coords[dim].values),
+            equal_nan=True,
+        ):
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Axis resolution helper
+# ---------------------------------------------------------------------------
+
+def axis_resolution(values: np.ndarray) -> float | None:
+    """Return the median absolute step size along a coordinate axis."""
+    if values.size <= 1:
+        return None
+    diffs = np.abs(np.diff(np.asarray(values, dtype=np.float64)))
+    finite = diffs[np.isfinite(diffs) & (diffs > 0.0)]
+    if finite.size == 0:
+        return None
+    return float(np.median(finite))
+
+
+def _can_coord_interp(source: xr.DataArray, template: xr.DataArray) -> bool:
+    """Return True if both arrays are 2-D with matching named dims and coords."""
+    return (
+        len(source.dims) == 2
+        and source.dims == template.dims
+        and all(dim in source.coords for dim in source.dims)
+        and all(dim in template.coords for dim in template.dims)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field resampling (continuous data)
+# ---------------------------------------------------------------------------
+
+def resample_field_to_template(
+    field: xr.DataArray,
+    template: xr.DataArray,
+    *,
+    copy_metadata: bool = True,
+    gap_fill: bool = True,
+) -> xr.DataArray:
+    """Resample a 2-D field to the spatial grid of *template*.
+
+    Strategy:
+    1. If the grids already match, return (optionally with metadata copy).
+    2. If both have coordinate arrays, use xarray linear interpolation.
+    3. Fall back to ``scipy.ndimage.zoom`` with bilinear interpolation.
+
+    When *gap_fill* is True (default), any remaining NaN pixels are filled
+    via nearest-neighbour interpolation then source-mean fallback.
+    """
+    if shares_template_grid(field, template):
+        return copy_spatial_metadata_like(field, template) if copy_metadata else field
+
+    resampled: xr.DataArray | None = None
+    if _can_coord_interp(field, template):
+        try:
+            interpolated = field.interp(
+                coords={dim: template.coords[dim] for dim in template.dims},
+                method="linear",
+            )
+            resampled = copy_spatial_metadata_like(interpolated, template) if copy_metadata else interpolated
+        except Exception as exc:
+            logger.warning(
+                "Linear interpolation failed for field %s (%s); falling back to zoom resampling",
+                getattr(field, "name", "?"),
+                exc,
+            )
+
+    if resampled is None:
+        src = np.asarray(field.values, dtype=np.float32)
+        if src.ndim != 2 or len(template.dims) != 2:
+            return field
+
+        h_out = int(template.sizes[template.dims[0]])
+        w_out = int(template.sizes[template.dims[1]])
+        if src.shape[0] == 0 or src.shape[1] == 0:
+            out: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
+        else:
+            out = ndimage.zoom(src, (h_out / src.shape[0], w_out / src.shape[1]), order=1)
+            out = out[:h_out, :w_out]
+            if out.shape != (h_out, w_out):
+                padded: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
+                padded[: out.shape[0], : out.shape[1]] = out
+                out = padded
+
+        resampled = xr.DataArray(
+            out,
+            dims=template.dims,
+            coords={dim: template.coords[dim] for dim in template.dims if dim in template.coords},
+            attrs=field.attrs,
+        )
+        if copy_metadata:
+            resampled = copy_spatial_metadata_like(resampled, template)
+
+    if gap_fill:
+        resampled = fill_nonfinite_like_template(resampled, field, template)
+
+    return resampled
+
+
+# ---------------------------------------------------------------------------
+# Mask resampling (boolean data, conservative / dilated)
+# ---------------------------------------------------------------------------
+
+def resample_mask_to_template(mask: xr.DataArray, template: xr.DataArray) -> xr.DataArray:
+    """Resample a boolean mask to *template* grid, dilating to avoid false negatives.
+
+    When downsampling from a finer grid, a maximum-filter is applied before
+    interpolation so that masked (True) pixels are not lost.
+    """
+    if shares_template_grid(mask, template):
+        return copy_spatial_metadata_like(mask.astype(bool), template)
+
+    if _can_coord_interp(mask, template):
+        source = np.asarray(mask.values, dtype=np.float32)
+        factor_y = 1
+        factor_x = 1
+        src_y_res = axis_resolution(np.asarray(mask.coords[mask.dims[0]].values))
+        src_x_res = axis_resolution(np.asarray(mask.coords[mask.dims[1]].values))
+        dst_y_res = axis_resolution(np.asarray(template.coords[template.dims[0]].values))
+        dst_x_res = axis_resolution(np.asarray(template.coords[template.dims[1]].values))
+        if src_y_res is not None and dst_y_res is not None and dst_y_res > src_y_res:
+            factor_y = max(1, int(np.ceil(dst_y_res / src_y_res)))
+        if src_x_res is not None and dst_x_res is not None and dst_x_res > src_x_res:
+            factor_x = max(1, int(np.ceil(dst_x_res / src_x_res)))
+        if factor_y > 1 or factor_x > 1:
+            source = ndimage.maximum_filter(source, size=(factor_y, factor_x), mode="nearest")
+
+        remapped = xr.DataArray(
+            source,
+            dims=mask.dims,
+            coords={dim: mask.coords[dim] for dim in mask.dims},
+            attrs=mask.attrs,
+        )
+        try:
+            interpolated = remapped.interp(
+                coords={dim: template.coords[dim] for dim in template.dims},
+                method="nearest",
+            )
+            values = np.asarray(interpolated.values, dtype=np.float32)
+            values = np.where(np.isfinite(values), values, 1.0)
+            return copy_spatial_metadata_like(
+                xr.DataArray(
+                    values > 0.5,
+                    dims=template.dims,
+                    coords={dim: template.coords[dim] for dim in template.dims if dim in template.coords},
+                    attrs=mask.attrs,
+                ),
+                template,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Mask coordinate-based resampling failed (%s); falling back to zoom resampling",
+                exc,
+            )
+
+    # Zoom-based fallback
+    src = np.asarray(mask.values, dtype=np.float32)
+    h_out = int(template.sizes[template.dims[0]])
+    w_out = int(template.sizes[template.dims[1]])
+    factor_y = max(1, src.shape[0] // h_out) if src.ndim == 2 and h_out > 0 else 1
+    factor_x = max(1, src.shape[1] // w_out) if src.ndim == 2 and w_out > 0 else 1
+    if src.ndim != 2:
+        out = np.ones((h_out, w_out), dtype=np.float32)
+    else:
+        dilated = ndimage.maximum_filter(src, size=(factor_y, factor_x), mode="nearest")
+        out = ndimage.zoom(dilated, (h_out / dilated.shape[0], w_out / dilated.shape[1]), order=0)
+        out = out[:h_out, :w_out]
+        if out.shape != (h_out, w_out):
+            padded: np.ndarray[Any, Any] = np.ones((h_out, w_out), dtype=np.float32)
+            padded[: out.shape[0], : out.shape[1]] = out
+            out = padded
+    return copy_spatial_metadata_like(
+        xr.DataArray(
+            out > 0.5,
+            dims=template.dims,
+            coords={dim: template.coords[dim] for dim in template.dims if dim in template.coords},
+            attrs=mask.attrs,
+        ),
+        template,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RT coefficient resampling
+# ---------------------------------------------------------------------------
+
+def resample_coefficients_to_template(
+    coeffs: RTCoefficients,
+    template: xr.DataArray,
+) -> RTCoefficients:
+    """Resample all fields of an RTCoefficients bundle to *template* grid."""
+    from siac.runtime import RTCoefficients as RTCoefficientsClass
+
+    def _resample_optional(field: xr.DataArray | None) -> xr.DataArray | None:
+        if field is None:
+            return None
+        if len(field.dims) == 2:
+            return resample_field_to_template(field, template)
+        if len(field.dims) == 3 and "param" in field.dims:
+            param_values = field.coords["param"].values if "param" in field.coords else np.arange(field.sizes["param"])
+            stacked = xr.concat(
+                [resample_field_to_template(field.sel(param=param, drop=True), template) for param in param_values],
+                dim="param",
+            )
+            return stacked.assign_coords(param=param_values).transpose("param", *template.dims)
+        return field
+
+    return RTCoefficientsClass(
+        xap=resample_field_to_template(coeffs.xap, template),
+        xbp=resample_field_to_template(coeffs.xbp, template),
+        xcp=resample_field_to_template(coeffs.xcp, template),
+        d_xap=_resample_optional(coeffs.d_xap),
+        d_xbp=_resample_optional(coeffs.d_xbp),
+        d_xcp=_resample_optional(coeffs.d_xcp),
+    )
+
+
+# ---------------------------------------------------------------------------
+# NaN gap-fill helper
+# ---------------------------------------------------------------------------
+
+def fill_nonfinite_like_template(
+    field: xr.DataArray,
+    source: xr.DataArray,
+    template: xr.DataArray,
+    *,
+    fallback_value: float = 0.0,
+) -> xr.DataArray:
+    """Fill NaN values in *field* using nearest-neighbour from *source*, then a constant."""
+    values = np.asarray(field.values, dtype=np.float32)
+    if np.all(np.isfinite(values)):
+        return field
+
+    filled = values.copy()
+    if _can_coord_interp(source, template):
+        try:
+            nearest = source.interp(
+                coords={dim: template.coords[dim] for dim in template.dims},
+                method="nearest",
+            )
+            nearest_values = np.asarray(nearest.values, dtype=np.float32)
+            filled = np.where(np.isfinite(filled), filled, nearest_values)
+        except Exception:
+            pass
+
+    if not np.all(np.isfinite(filled)):
+        source_values = np.asarray(source.values, dtype=np.float32)
+        finite_source = source_values[np.isfinite(source_values)]
+        fill_value = float(finite_source.mean()) if finite_source.size else float(fallback_value)
+        n_nan = int(np.sum(~np.isfinite(filled)))
+        logger.warning(
+            "Filling %d remaining NaN pixels in field %s with source mean %.4g",
+            n_nan,
+            getattr(field, "name", "?"),
+            fill_value,
+        )
+        filled = np.where(np.isfinite(filled), filled, np.float32(fill_value))
+
+    return field.copy(data=filled)
+
+
+def resample_field_for_correction(
+    field: xr.DataArray,
+    template: xr.DataArray,
+    *,
+    fallback_value: float = 0.0,
+) -> xr.DataArray:
+    """Resample an atmosphere field to the correction grid and guarantee finiteness."""
+    return fill_nonfinite_like_template(
+        resample_field_to_template(field, template, copy_metadata=False, gap_fill=False),
+        field,
+        template,
+        fallback_value=fallback_value,
+    )
+
+
+__all__ = [
+    "axis_resolution",
+    "fill_nonfinite_like_template",
+    "resample_coefficients_to_template",
+    "resample_field_for_correction",
+    "resample_field_to_template",
+    "resample_mask_to_template",
+    "shares_template_grid",
+]

--- a/python/siac/runtime/models.py
+++ b/python/siac/runtime/models.py
@@ -100,7 +100,8 @@ class GeometryAngles:
 
     @property
     def raa(self) -> xr.DataArray:
-        return _as_data_array(self.vaa - self.saa)
+        """Relative azimuth angle in radians, wrapped to [0, 2*pi)."""
+        return _as_data_array(np.abs(self.vaa - self.saa) % (2.0 * np.pi))
 
     @property
     def cos_sza(self) -> xr.DataArray:
@@ -226,7 +227,9 @@ class RTCoefficients:
 
     def apply_correction(self, toa: xr.DataArray) -> xr.DataArray:
         y = _as_data_array(self.xap * toa - self.xbp)
-        return _as_data_array(y / (1.0 + self.xcp * y))
+        denom = _as_data_array(1.0 + self.xcp * y)
+        stable = _as_data_array(np.isfinite(denom) & (np.abs(denom) > 1.0e-10))
+        return _as_data_array((y / denom).where(stable))
 
     def simulate_toa(self, boa: xr.DataArray) -> xr.DataArray:
         """Forward-simulate dimensionless TOA reflectance from BOA reflectance."""

--- a/python/siac/workflows/pipeline.py
+++ b/python/siac/workflows/pipeline.py
@@ -4,7 +4,6 @@ Pipeline orchestration for SIAC atmospheric correction.
 
 from __future__ import annotations
 
-import inspect
 import logging
 import time
 from collections.abc import Callable
@@ -287,90 +286,23 @@ def _build_aot_scatter_diagnostics(
     return tuple(diagnostics)
 
 
-def _shares_template_grid(field: Any, template: Any) -> bool:
-    if tuple(field.shape) != tuple(template.shape) or field.dims != template.dims:
-        return False
-    for axis in template.dims:
-        template_has_coord = axis in template.coords
-        field_has_coord = axis in field.coords
-        if template_has_coord != field_has_coord:
-            return False
-        if not template_has_coord:
-            continue
-        if not np.array_equal(
-            np.asarray(template.coords[axis].values),
-            np.asarray(field.coords[axis].values),
-            equal_nan=True,
-        ):
-            return False
-    return True
-
-
-def _resample_field_to_template(field: Any, template: Any) -> Any:
-    if _shares_template_grid(field, template):
-        return field
-    field_dims = tuple(getattr(field, "dims", ()))
-    template_dims = tuple(getattr(template, "dims", ()))
-    field_coords = getattr(field, "coords", {})
-    template_coords = getattr(template, "coords", {})
-    if (
-        len(field_dims) == 2
-        and field_dims == template_dims
-        and all(dim in field_coords for dim in field_dims)
-        and all(dim in template_coords for dim in template_dims)
-    ):
-        try:
-            return field.interp(
-                coords={dim: template.coords[dim] for dim in template_dims},
-                method="linear",
-            )
-        except Exception:
-            logger.debug(
-                "Interpolation failed for field %s; falling back to scipy zoom.",
-                getattr(field, "name", "?"),
-                exc_info=True,
-            )
-
-    src = np.asarray(field.values, dtype=np.float32)
-    if src.ndim != 2 or len(template_dims) != 2:
-        return field
-
-    from scipy import ndimage
-
-    h_out = int(template.sizes[template_dims[0]])
-    w_out = int(template.sizes[template_dims[1]])
-    if src.shape[0] == 0 or src.shape[1] == 0:
-        out: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
-    else:
-        out = ndimage.zoom(src, (h_out / src.shape[0], w_out / src.shape[1]), order=1)
-        out = out[:h_out, :w_out]
-        if out.shape != (h_out, w_out):
-            padded: np.ndarray[Any, Any] = np.full((h_out, w_out), np.nan, dtype=np.float32)
-            padded[: out.shape[0], : out.shape[1]] = out
-            out = padded
-
-    return field.__class__(
-        out,
-        dims=template.dims,
-        coords={d: template.coords[d] for d in template.dims if d in template.coords},
-    )
-
-
 def _geometry_for_atmo_grid(
     geometry: GeometryAngles,
     atmo: AtmosphericState,
 ) -> GeometryAngles:
+    from siac.geo.resample import resample_field_to_template, shares_template_grid
+
     template = atmo.aot
     if all(
-        _shares_template_grid(field, template)
+        shares_template_grid(field, template)
         for field in (geometry.sza, geometry.saa, geometry.vza, geometry.vaa)
     ):
         return geometry
     return GeometryAngles(
-        sza=_resample_field_to_template(geometry.sza, template),
-        saa=_resample_field_to_template(geometry.saa, template),
-        vza=_resample_field_to_template(geometry.vza, template),
-        vaa=_resample_field_to_template(geometry.vaa, template),
+        sza=resample_field_to_template(geometry.sza, template),
+        saa=resample_field_to_template(geometry.saa, template),
+        vza=resample_field_to_template(geometry.vza, template),
+        vaa=resample_field_to_template(geometry.vaa, template),
     )
 
 
@@ -492,61 +424,31 @@ def _call_grid_assembler(
     aerosol_resolution_m: float,
     sharp_transition_filter: Any | None = None,
 ) -> SolverInputBundle:
-    grid_assembler_fn = cast("Callable[..., SolverInputBundle]", grid_assembler)
+    """Call the grid assembler with a standardised interface.
 
-    def _call_with_optional_filter(
-        *args: Any,
-        supports_filter: bool,
-        **kwargs: Any,
-    ) -> SolverInputBundle:
-        if supports_filter and sharp_transition_filter is not None:
-            kwargs["sharp_transition_filter"] = sharp_transition_filter
-        try:
-            return grid_assembler_fn(*args, **kwargs)
-        except TypeError:
-            if not supports_filter or "sharp_transition_filter" not in kwargs:
-                raise
-            kwargs.pop("sharp_transition_filter", None)
-            return grid_assembler_fn(*args, **kwargs)
+    The assembler is expected to accept the signature::
 
+        (obs, atmo, surface, rt_model, *, aerosol_resolution_m, sharp_transition_filter=None)
+
+    For backwards compatibility with assemblers that do not accept the
+    ``sharp_transition_filter`` keyword, a single fallback attempt is made
+    without it.
+    """
     try:
-        signature = inspect.signature(grid_assembler_fn)
-    except (TypeError, ValueError):
-        return _call_with_optional_filter(
-            obs,
-            atmo,
-            surface,
-            rt_model,
+        return grid_assembler(
+            obs, atmo, surface, rt_model,
             aerosol_resolution_m=aerosol_resolution_m,
-            supports_filter=True,
+            sharp_transition_filter=sharp_transition_filter,
         )
-
-    params = tuple(signature.parameters.values())
-    if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params) or "aerosol_resolution_m" in signature.parameters:
-        return _call_with_optional_filter(
-            obs,
-            atmo,
-            surface,
-            rt_model,
+    except TypeError:
+        logger.debug(
+            "Grid assembler rejected sharp_transition_filter keyword; retrying without it",
+            exc_info=True,
+        )
+        return grid_assembler(
+            obs, atmo, surface, rt_model,
             aerosol_resolution_m=aerosol_resolution_m,
-            supports_filter=(
-                "sharp_transition_filter" in signature.parameters
-                or any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params)
-            ),
         )
-    if any(param.kind is inspect.Parameter.VAR_POSITIONAL for param in params):
-        return grid_assembler_fn(obs, atmo, surface, rt_model, _DEFAULT_AUX_RESOLUTION_M, aerosol_resolution_m)
-
-    positional_params = [
-        param
-        for param in params
-        if param.kind in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
-    ]
-    if len(positional_params) >= 6:
-        return grid_assembler_fn(obs, atmo, surface, rt_model, _DEFAULT_AUX_RESOLUTION_M, aerosol_resolution_m)
-    if len(positional_params) >= 5:
-        return grid_assembler_fn(obs, atmo, surface, rt_model, aerosol_resolution_m)
-    return grid_assembler_fn(obs, atmo, surface, rt_model)
 
 
 def _call_with_retries(

--- a/python/siac/workflows/pipeline.py
+++ b/python/siac/workflows/pipeline.py
@@ -63,10 +63,7 @@ AtmoPriorFn = Callable[
     AtmosphericState,
 ]
 SurfacePriorFn = Callable[[ObservationBundle, AtmosphericState | None, Any, float], SurfacePrior]
-GridAssemblerFn = Callable[
-    [ObservationBundle, AtmosphericState, SurfacePrior, Any, float, float, Any | None],
-    SolverInputBundle,
-]
+GridAssemblerFn = Callable[..., SolverInputBundle]
 SolverFn = Callable[[SolverInputBundle, Any], SolvedAtmosphere]
 CorrectorFn = Callable[[ObservationBundle, SolvedAtmosphere, Any], CorrectionResult]
 

--- a/tests/integration/test_e2e_synthetic.py
+++ b/tests/integration/test_e2e_synthetic.py
@@ -140,7 +140,7 @@ class TestE2ESynthetic:
             _ = (observation, atmo_state, rt_model, resolution)
             return surface
 
-        def grid_assembler(o, a, s, rt, aux_res=500.0, aero_res=1000.0):
+        def grid_assembler(o, a, s, rt, **_kwargs):
             return assemble_grids(o, a, s, rt)
 
         def solver(inputs, config):

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -214,7 +214,7 @@ class TestRunPipeline:
             call_counts["m3"] += 1
             return mock_surface_prior
 
-        def assemble(obs, at, sp, rt, aux_res=500.0, aero_res=1000.0):
+        def assemble(obs, at, sp, rt, **_kwargs):
             call_counts["m4"] += 1
             return mock_solver_input_bundle
 
@@ -262,7 +262,7 @@ class TestRunPipeline:
             order.append("m3")
             return mock_surface_prior
 
-        def assemble(obs, at, sp, rt, aux_res=500.0, aero_res=1000.0):
+        def assemble(obs, at, sp, rt, **_kwargs):
             order.append("m4")
             return mock_solver_input_bundle
 
@@ -427,7 +427,7 @@ class TestConcurrency:
         def pp(path, aoi=None):
             return mock_observation_bundle
 
-        def assemble(obs, at, sp, rt, aux_res=500.0, aero_res=1000.0):
+        def assemble(obs, at, sp, rt, **_kwargs):
             return mock_solver_input_bundle
 
         def solve(inputs, cfg):
@@ -470,7 +470,7 @@ class TestConcurrency:
         def pp(path, aoi=None):
             return mock_observation_bundle
 
-        def assemble(obs, at, sp, rt, aux_res=500.0, aero_res=1000.0):
+        def assemble(obs, at, sp, rt, **_kwargs):
             return mock_solver_input_bundle
 
         def solve(inputs, cfg):
@@ -532,8 +532,8 @@ class TestConcurrency:
             _ = (path, aoi)
             return mock_observation_bundle
 
-        def assemble(obs, at, sp, rt, aux_res=500.0, aero_res=1000.0):
-            _ = (obs, at, sp, rt, aux_res, aero_res)
+        def assemble(obs, at, sp, rt, **_kwargs):
+            _ = (obs, at, sp, rt)
             return mock_solver_input_bundle
 
         def solve(inputs, cfg):

--- a/tests/unit/test_assembly_helper_modules.py
+++ b/tests/unit/test_assembly_helper_modules.py
@@ -406,7 +406,8 @@ def test_resample_helpers_and_corrector_cover_interpolation_zoom_and_passthrough
         xr.DataArray(np.empty((0, 0), dtype=np.float32), dims=["y", "x"]),
         template,
     )
-    assert np.isnan(empty.values).all()
+    # Empty source is gap-filled to 0.0 (fallback when no finite source values exist)
+    assert np.all(empty.values == 0.0)
 
     three_d = xr.DataArray(np.ones((1, 2, 2), dtype=np.float32), dims=["band", "y", "x"])
     assert runtime_mod._resample_field_to_template(three_d, template) is three_d
@@ -646,8 +647,9 @@ def test_resample_field_to_template_falls_back_after_interp_error_and_pads_zoom(
 
     assert out.shape == (3, 3)
     np.testing.assert_allclose(out.values[0, :2], np.array([5.0, 6.0], dtype=np.float32))
-    assert np.isnan(out.values[0, 2])
-    assert np.isnan(out.values[1:, :]).all()
+    # NaN regions are gap-filled with source mean (1.0 + 2.0) / 2 = 1.5
+    assert np.isfinite(out.values[0, 2])
+    assert np.isfinite(out.values[1:, :]).all()
 
 
 def test_surface_helper_selection_and_mapping_runtime(

--- a/tests/unit/test_resolve.py
+++ b/tests/unit/test_resolve.py
@@ -13,7 +13,6 @@ from siac.app.assembly import (
     _build_kernel_surface_prior,
     _build_monthly_surface_prior,
     _build_whittaker_surface_prior,
-    _resample_field_to_template,
     resolve_atmo_provider,
     resolve_corrector,
     resolve_grid_assembler,
@@ -23,6 +22,7 @@ from siac.app.assembly import (
     resolve_solver,
     resolve_surface_prior_provider,
 )
+from siac.geo.resample import resample_field_to_template as _resample_field_to_template
 from siac.observability import ExecutionObserver, bind_execution_observer
 
 

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -36,10 +36,10 @@ class TestGeometryAngles:
         np.testing.assert_allclose(geom.sza.values, 0.5)
 
     def test_raa_property(self, sample_angles):
-        """RAA should be computed from vaa - saa."""
+        """RAA should be |vaa - saa| wrapped to [0, 2*pi)."""
         geom = GeometryAngles(**sample_angles)
 
-        expected_raa = 1.5 - 2.5  # vaa - saa
+        expected_raa = np.abs(1.5 - 2.5) % (2.0 * np.pi)  # |vaa - saa| mod 2pi
         np.testing.assert_allclose(geom.raa.values, expected_raa)
 
     def test_cos_properties(self, sample_angles):


### PR DESCRIPTION
- Extract shared resampling utilities into siac.geo.resample, eliminating 3-way duplication across pipeline.py, atmospheric.py, and _assembly_runtime.py (~460 net lines removed)
- Fix silent alpha/band_weight_power bug: user-configured SolverAlgorithmConfig.alpha was ignored because CostFunctionConfig defaulted to -2.0 independently; now threaded through MultiGridConfig
- Replace fragile inspect.signature() grid assembler dispatch with simple keyword-arg call and TypeError fallback
- Simplify __init__.py lazy loading with dict-based lookup table
- Deduplicate config schema with _ConfigShortcutsMixin, remove empty Resolved* subclasses and redundant provider setters
- Add RTModelBackend protocol typing to solver and corrector boundaries
- Wrap RAA to [0, 2*pi) and add stability guard in apply_correction()
- Vectorize sparse Laplacian boundary loop with boolean indexing
- Pre-allocate solver DataArrays to reduce xarray overhead per iteration